### PR TITLE
Add PEP-518 metadata

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,10 +154,6 @@ Using Koelsynth to produce audio involves three steps:
 3. Getting audio frames from the sequencer
 
 ### Installation
-You may have to install the following packages before installing Koelsynth with pip.
-1. wheel (to avoid some warnings)
-2. pybind11 (used for wrapping C++)
-
 Add the following to your project's requirements.txt:
 ```
 git+https://github.com/charstorm/koelsynth.git@main

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,3 @@
+[build-system]
+requires=["pybind11", "setuptools"]
+build-backend="setuptools.build_meta"


### PR DESCRIPTION
Hello! I found this package through a post on Hacker News. I haven't had the chance to play around with it yet, but I saw an opportunity to simplify the installation process through [PEP-518](https://peps.python.org/pep-0518/). That PEP is meant to solve the problem of users needing to install build-time prerequisites in order to run the setup script.

I tested it like this, using this PR branch on my fork:
```
pip install 'git+https://github.com/dranjan/koelsynth@pep-518'
```